### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: :index
 
   def index
-    @items = Item.order('created_at DESC')
+    @items = Item.all
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: :index
 
   def index
-    @items = Item.all
+    @items = Item.order('created_at DESC')
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,12 +126,12 @@
     <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <%# @items.each do |item| %> 
+    <% if @items.present? %>
+      <% @items.each do |item| %> 
         <li class='list'>
           <%= link_to "#" do %>
           <div class='item-img-content'>
-            <%= image_tag "item-sample.png", class: "item-img" %>
+            <%= image_tag item.image, class: "item-img" %>
             
             <%# 商品が売れていればsold outを表示しましょう %>
             <%# if @item.present? %>
@@ -144,10 +144,10 @@
           </div>
           <div class='item-info'>
             <h3 class='item-name'>
-              <%= "商品名" %>
+              <%= item.name %>
             </h3>
             <div class='item-price'>
-              <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+              <span><%= item.price %>円<br><%= item.shipping_fee.name %></span>
               <div class='star-btn'>
                 <%= image_tag "star.png", class:"star-icon" %>
                 <span class='star-count'>0</span>
@@ -156,11 +156,9 @@
           </div>
           <% end %>
         </li>
-      <%# end %>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
+      <% end %>
+    <% else %>
       <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -179,7 +177,7 @@
         <% end %>
       </li>
       <%# //商品がある場合は表示されないようにしましょう %>	
-      <%# /商品がない場合のダミー %>
+    <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,11 +126,12 @@
     <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
 
-      <% @items.each do |item| %> 
+      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <%# @items.each do |item| %> 
         <li class='list'>
           <%= link_to "#" do %>
           <div class='item-img-content'>
-            <%= image_tag item.image, class: "item-img" %>
+            <%= image_tag "item-sample.png", class: "item-img" %>
             
             <%# 商品が売れていればsold outを表示しましょう %>
             <%# if @item.present? %>
@@ -143,10 +144,10 @@
           </div>
           <div class='item-info'>
             <h3 class='item-name'>
-              <%= item.name %>
+              <%= "商品名" %>
             </h3>
             <div class='item-price'>
-              <span><%= item.price %>円<br><%= item.shipping_fee.name %></span>
+              <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
               <div class='star-btn'>
                 <%= image_tag "star.png", class:"star-icon" %>
                 <span class='star-count'>0</span>
@@ -155,7 +156,30 @@
           </div>
           <% end %>
         </li>
-      <% end %>
+      <%# end %>
+      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+
+      <%# 商品がない場合のダミー %>
+      <%# 商品がある場合は表示されないようにしましょう %>
+      <li class='list'>
+        <%= link_to '#' do %>
+        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
+        <div class='item-info'>
+          <h3 class='item-name'>
+          商品を出品してね！	
+        </h3>
+        <div class='item-price'>	
+          <span>99999999円<br>(税込み)</span>	
+            <div class='star-btn'>	
+              <%= image_tag "star.png", class:"star-icon" %>	
+              <span class='star-count'>0</span>
+            </div>
+          </div>
+          </div>
+        <% end %>
+      </li>
+      <%# //商品がある場合は表示されないようにしましょう %>	
+      <%# /商品がない場合のダミー %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,12 +126,11 @@
     <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <%# @items.each do |item| %> 
+      <% @items.each do |item| %> 
         <li class='list'>
           <%= link_to "#" do %>
           <div class='item-img-content'>
-            <%= image_tag "item-sample.png", class: "item-img" %>
+            <%= image_tag item.image, class: "item-img" %>
             
             <%# 商品が売れていればsold outを表示しましょう %>
             <%# if @item.present? %>
@@ -144,10 +143,10 @@
           </div>
           <div class='item-info'>
             <h3 class='item-name'>
-              <%= "商品名" %>
+              <%= item.name %>
             </h3>
             <div class='item-price'>
-              <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+              <span><%= item.price %>円<br><%= item.shipping_fee.name %></span>
               <div class='star-btn'>
                 <%= image_tag "star.png", class:"star-icon" %>
                 <span class='star-count'>0</span>
@@ -156,30 +155,7 @@
           </div>
           <% end %>
         </li>
-      <%# end %>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-          商品を出品してね！	
-        </h3>
-        <div class='item-price'>	
-          <span>99999999円<br>(税込み)</span>	
-            <div class='star-btn'>	
-              <%= image_tag "star.png", class:"star-icon" %>	
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-          </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>	
-      <%# /商品がない場合のダミー %>
+      <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>


### PR DESCRIPTION
# What
商品一覧表示機能

# Why
商品一覧表示機能の実装のため

- ログイン状態で商品一覧表示ページを見ることができる
https://gyazo.com/d80790d608de98ad1a4f9f384525dd65

-  ログアウト状態のユーザーでも、商品一覧表示ページを見ることができる
https://gyazo.com/cc3fe350d20c5295960786cfd0e86f0f

- 上から、出品された日時が新しい順に表示されること、出品した商品の一覧表示ができていること
https://gyazo.com/0a7ea3c7d8f765d36cf57a00e5a82134

- 画像が表示されており画像がリンク切れなどになっていないこと、「画像/価格/商品名」の3つの情報について表示できていること
https://gyazo.com/47a51c6b25df2108d87d738b386b85e2

- 「売却済みの商品は、画像上に『sold out』の文字が表示されるようになっていること」という機能に関しては、商品購入機能をまだ実装していないため、実装を行っていません。